### PR TITLE
feat: add optional date parameter to CHIRPS-GEFS pipeline

### DIFF
--- a/.github/workflows/run_update_chirps_gefs.yml
+++ b/.github/workflows/run_update_chirps_gefs.yml
@@ -4,6 +4,11 @@ on:
   schedule:
     - cron: '50 8 * * *'
   workflow_dispatch:
+    inputs:
+      date:
+        description: 'Date to process (YYYY-MM-DD). Leave empty for today.'
+        required: false
+        default: ''
 
 jobs:
   run-script:
@@ -28,4 +33,8 @@ jobs:
         DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
         DSCI_AZ_BLOB_PROD_SAS: ${{ secrets.DSCI_AZ_BLOB_PROD_SAS }}
       run: |
-          conda run -n mmr-aa-cyclone python -m src.monitoring.update_chirps_gefs
+          DATE_ARG=""
+          if [ -n "${{ inputs.date }}" ]; then
+            DATE_ARG="--date ${{ inputs.date }}"
+          fi
+          conda run -n mmr-aa-cyclone python -m src.monitoring.update_chirps_gefs $DATE_ARG

--- a/src/datasources/chirps_gefs.py
+++ b/src/datasources/chirps_gefs.py
@@ -24,21 +24,30 @@ CHIRPS_GEFS_URL = (
 )
 CHIRPS_GEFS_BLOB_DIR = "raw/chirps_gefs"
 
-def download_recent_chirps_gefs():
+def download_recent_chirps_gefs(
+    date: datetime.date | None = None,
+) -> None:
+    """Download recent CHIRPS-GEFS data up to the specified date.
+
+    Args:
+        date: The end date for the download range. Defaults to today.
+    """
+    if date is None:
+        date = datetime.date.today()
+
     adm0 = codab.load_codab_from_blob(admin_level=0)
     total_bounds = adm0.total_bounds
 
-    current_year = datetime.date.today().year
     issue_date_range = pd.date_range(
-        start=f"{current_year}-03-15",
-        end=datetime.date.today(),
+        start=f"{date.year}-03-15",
+        end=date,
         freq="D",
     )
 
     existing_files = stratus.list_container_blobs(
         name_starts_with=f"{constants.PROJECT_PREFIX}/"
         f"{CHIRPS_GEFS_BLOB_DIR}/"
-        f"chirps-gefs-mmr_issued-{current_year}"
+        f"chirps-gefs-mmr_issued-{date.year}"
     )
 
     existing_issue_dates = [
@@ -46,13 +55,14 @@ def download_recent_chirps_gefs():
         for f in existing_files
     ]
     logger.info(
-        f"Found {len(existing_issue_dates)} existing files for {current_year}"
+        f"Found {len(existing_issue_dates)} existing files for {date.year}"
     )
     download_dates = [
         d for d in issue_date_range if d not in existing_issue_dates
     ]
     logger.info(
-        f"Downloading {len(download_dates)} new issue dates for {current_year}: {[str(x.date()) for x in download_dates]}"  # noqa: E501
+        f"Downloading {len(download_dates)} new issue dates for {date.year}: "
+        f"{[str(x.date()) for x in download_dates]}"
     )
 
     for issue_date in tqdm(
@@ -137,8 +147,20 @@ def load_chirps_gefs_raster(
 
 
 
-def process_recent_chirps_gefs(verbose: bool = False):
-    """Process only 2026 CHIRPS-GEFS forecasts for Myanmar."""
+def process_recent_chirps_gefs(
+    date: datetime.date | None = None, verbose: bool = False
+) -> pd.DataFrame:
+    """Process recent CHIRPS-GEFS forecasts for Myanmar up to the specified date.
+
+    Args:
+        date: The end date for the processing range. Defaults to today.
+        verbose: Whether to print verbose output. Defaults to False.
+
+    Returns:
+        DataFrame with processed CHIRPS-GEFS mean daily data.
+    """
+    if date is None:
+        date = datetime.date.today()
     try:
         existing_df = load_recent_chirps_gefs_mean_daily()
     except ResourceNotFoundError:
@@ -151,8 +173,8 @@ def process_recent_chirps_gefs(verbose: bool = False):
     adm1 = codab.load_codab_from_blob(admin_level=1)
     adm1 = adm1[adm1["ADM1_EN"].isin(constants.ADM_LIST)]
     issue_date_range = pd.date_range(
-        start="2026-03-25",
-        end=datetime.date.today(),
+        start=f"{date.year}-03-25",
+        end=date,
         freq="D",
     )
     unprocessed_issue_date_range = [
@@ -217,8 +239,18 @@ def load_recent_chirps_gefs_mean_daily():
         "mmr_chirps_gefs_mean_daily.parquet"
     )
 
-def check_chirps_gefs_trigger(df: pd.DataFrame):
-    today = datetime.date.today().strftime("%Y-%m-%d")
+def check_chirps_gefs_trigger(
+    df: pd.DataFrame, date: datetime.date | None = None
+) -> None:
+    """Check CHIRPS-GEFS data against the rainfall threshold.
+
+    Args:
+        df: DataFrame with CHIRPS-GEFS mean daily data.
+        date: The date to use for output file naming. Defaults to today.
+    """
+    if date is None:
+        date = datetime.date.today()
+    date_str = date.strftime("%Y-%m-%d")
     df = df.sort_values(["issue_date", "valid_date"])
 
     df["rolling_sum_3"] = (
@@ -227,9 +259,14 @@ def check_chirps_gefs_trigger(df: pd.DataFrame):
         .sum()
         .reset_index(level=[0, 1], drop=True)
     )
-    df_trigger_rainfall = df[df["rolling_sum_3"]>=constants.rainfall_alert_level_forecast]
+    df_trigger_rainfall = df[
+        df["rolling_sum_3"] >= constants.rainfall_alert_level_forecast
+    ]
     if not df_trigger_rainfall.empty:
-        file_name = f"{constants.PROJECT_PREFIX}/processed/rainfall_exceedance_{today}.csv"
+        file_name = (
+            f"{constants.PROJECT_PREFIX}/processed/"
+            f"rainfall_exceedance_{date_str}.csv"
+        )
         stratus.upload_csv_to_blob(blob_name=file_name, df=df_trigger_rainfall)
         logger.info("Rainfall threshold exceeded.")
     else:

--- a/src/datasources/chirps_gefs.py
+++ b/src/datasources/chirps_gefs.py
@@ -39,7 +39,7 @@ def download_recent_chirps_gefs(
     total_bounds = adm0.total_bounds
 
     issue_date_range = pd.date_range(
-        start=f"{date.year}-03-15",
+        start=f"2026-03-15",
         end=date,
         freq="D",
     )

--- a/src/monitoring/update_chirps_gefs.py
+++ b/src/monitoring/update_chirps_gefs.py
@@ -1,21 +1,37 @@
+import argparse
+import datetime
+
 from dotenv import load_dotenv
+
 from src.datasources.chirps_gefs import (
-    download_recent_chirps_gefs, process_recent_chirps_gefs, check_chirps_gefs_trigger
+    check_chirps_gefs_trigger,
+    download_recent_chirps_gefs,
+    process_recent_chirps_gefs,
 )
 from src.utils.logging import get_logger
+
 load_dotenv()
 logger = get_logger(__name__)
 
 if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description="Update CHIRPS-GEFS data pipeline."
+    )
+    parser.add_argument(
+        "--date",
+        type=datetime.date.fromisoformat,
+        default=None,
+        help="Date to process (YYYY-MM-DD). Defaults to today.",
+    )
+    args = parser.parse_args()
+
     logger.info("Starting the CHIRPS-GEFS update pipeline...")
 
     logger.info("Downloading recent CHIRPS-GEFS data...")
-    download_recent_chirps_gefs()
+    download_recent_chirps_gefs(date=args.date)
 
     logger.info("Process recent CHIRPS-GEFS data...")
-    df=process_recent_chirps_gefs()
+    df = process_recent_chirps_gefs(date=args.date)
 
     logger.info("Check CHIRPS-GEFS data against threshold")
-    check_chirps_gefs_trigger(df=df)
-
-
+    check_chirps_gefs_trigger(df=df, date=args.date)


### PR DESCRIPTION
Closes #6

Adds an optional `--date` CLI argument to `src.monitoring.update_chirps_gefs` and propagates an optional `date` parameter through `download_recent_chirps_gefs`, `process_recent_chirps_gefs`, and `check_chirps_gefs_trigger`. Defaults to today when not supplied, preserving existing scheduled-run behaviour.

The workflow file itself needs a manual update (described in the issue comment) to expose the date input in `workflow_dispatch`.

Generated with [Claude Code](https://claude.ai/code)