### PR TITLE
Improve CHIRPS-GEFS pipeline, CMA monitoring, and tests

### DIFF
--- a/.github/workflows/run_update_cma.yml
+++ b/.github/workflows/run_update_cma.yml
@@ -1,0 +1,32 @@
+name: Download recent CMA data
+
+on:
+  schedule:
+    - cron: '0 8 * * *'
+    - cron: '0 20 * * *'
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v4
+
+    - name: Set up Conda
+      uses: conda-incubator/setup-miniconda@v3
+      with:
+        miniforge-variant: Miniforge3
+        use-mamba: true
+        activate-environment: mmr-aa-cyclone
+        environment-file: environment.yml
+
+    - name: Run script
+      env:
+        DSCI_AZ_BLOB_DEV_SAS: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS }}
+        DSCI_AZ_BLOB_DEV_SAS_WRITE: ${{ secrets.DSCI_AZ_BLOB_DEV_SAS_WRITE }}
+        DSCI_AZ_BLOB_PROD_SAS: ${{ secrets.DSCI_AZ_BLOB_PROD_SAS }}
+      run: |
+           conda run -n mmr-aa-cyclone python -m src.monitoring.wind_speed_monitoring_cma

--- a/src/monitoring/slack_bot.py
+++ b/src/monitoring/slack_bot.py
@@ -21,6 +21,7 @@ GITHUB_REPO = os.getenv("GITHUB_REPO", "ocha-dap/ds-aa-mmr-cyclones")
 WORKFLOWS = [
     "run_monitoring.yml",
     "run_update_ecmwf.yml",
+    "run_update_cma.yml",
     "run_update_chirps_gefs.yml",
 ]
 

--- a/src/monitoring/wind_speed_monitoring_cma.py
+++ b/src/monitoring/wind_speed_monitoring_cma.py
@@ -10,15 +10,11 @@ from src.utils.utils_windpseed import compute_distance_to_land, compute_wind_spe
 from src.utils.logging import get_logger
 from src.datasources import codab
 import src.utils.constants as constants
-from src.utils.utils_cma import load_bob_tc_forecasts
+from src.utils.utils_cma import load_typhoon_tc_forecasts
 import geopandas as gpd
-import matplotlib.pyplot as plt
 
 load_dotenv()
 logger = get_logger(__name__)
-
-from climada_petals.hazard.tc_tracks_forecast import TCForecast
-from climada.hazard.centroids import Centroids
 
 # ----------------------------------------------------
 # PARAMETERS
@@ -30,100 +26,66 @@ WIND_THRESHOLD = constants.wind_speed_alert_level # wind speed threshold (knots)
 # DOWNLOAD CYCLONE FORECAST TRACKS
 # ----------------------------------------------------
 
-def download_tracks_cma():
-    """
-    Download CMA data
-    """
+def download_tracks_cma() -> pd.DataFrame:
+    """Download and normalise CMA typhoon forecast data.
 
-    data = load_bob_tc_forecasts(blob_prefix="ds-cma-datasharing/cma_ftp/data_out/typhoon/")
-
-    return data
+    Returns:
+        DataFrame with columns renamed to match the shared processing
+        utilities: ``sid``, ``time``, ``max_sustained_wind``,
+        ``ensemble_number``, ``storm_name``, ``lon``, ``lat``.
+    """
+    df = load_typhoon_tc_forecasts(
+        blob_prefix="ds-cma-datasharing/cma_ftp/data_out/typhoon/"
+    )
+    df = df.rename(
+        columns={
+            "storm_id": "sid",
+            "valid_datetime": "time",
+            "wind_speed_ms": "max_sustained_wind",
+        }
+    )
+    df["ensemble_number"] = 0
+    return df
 
 
 # ----------------------------------------------------
 # FILTER CYCLONES NEAR MYANMAR
 # ----------------------------------------------------
 
-def filter_myanmar_tracks(tracks, buffer_km=200):
-    """
-    Keep only storms that pass near Myanmar (buffered area).
-    """
+def filter_myanmar_tracks(tracks: pd.DataFrame, buffer_km: int = 200) -> gpd.GeoDataFrame:
+    """Keep only storms that pass near Myanmar (buffered area).
 
-    # --- Load and buffer Myanmar ---
+    Args:
+        tracks: DataFrame returned by ``download_tracks_cma`` with columns
+            ``lon``, ``lat``, ``sid``, ``time``, ``max_sustained_wind``,
+            ``ensemble_number``, and ``storm_name``.
+        buffer_km: Buffer distance in kilometres around Myanmar.
+
+    Returns:
+        GeoDataFrame of track points within the buffered Myanmar boundary.
+    """
     adm0 = codab.load_codab_from_blob(admin_level=0)
-
     gdf_adm_projected = adm0.to_crs(epsg=constants.MMR_UTM)
-
     gdf_adm_projected["geometry"] = gdf_adm_projected.geometry.buffer(
-        buffer_km* 1000
+        buffer_km * 1000
     )
-
     gdf_adm_buffered = gdf_adm_projected.to_crs(epsg=4326)
 
-    # --- Convert tracks to GeoDataFrame ---
-    dfs = []
-
-    for i, track in enumerate(tracks):
-
-        df = track.to_dataframe().reset_index()
-
-        df["storm_name"] = track.name
-        df["sid"] = track.sid
-        df["ensemble_number"] = track.ensemble_number
-        df["is_ensemble"] = track.is_ensemble
-        df["category"] = track.attrs.get("category", "N/A")
-
-        dfs.append(df)
-
-    gdf_all = pd.concat(dfs, ignore_index=True)
-
     gdf_all = gpd.GeoDataFrame(
-        gdf_all,
-        geometry=gpd.points_from_xy(gdf_all.lon, gdf_all.lat),
-        crs="EPSG:4326"
+        tracks,
+        geometry=gpd.points_from_xy(tracks.lon, tracks.lat),
+        crs="EPSG:4326",
     )
 
-    # --- Spatial filter (points within buffer) ---
     gdf_filtered = gpd.sjoin(
         gdf_all,
         gdf_adm_buffered,
         how="inner",
-        predicate="within"
+        predicate="within",
     ).drop(columns="index_right")
 
     return gdf_filtered
 
-
-# ----------------------------------------------------
-# PROCESS STORM
-# ----------------------------------------------------
-def track_to_gdf(track):
-    """
-    Convert CLIMADA track to GeoDataFrame
-    """
-
-    df = track.to_dataframe().reset_index()
-
-    gdf = gpd.GeoDataFrame(
-        df,
-        geometry=gpd.points_from_xy(df.lon, df.lat),
-        crs="EPSG:4326"
-    )
-
-    return gdf
-
-def process_storm(track, gdf_land):
-
-    # convert track
-    gdf_track = track_to_gdf(track)
-
-    # distance to land
-    gdf_track = compute_distance_to_land(gdf_track, gdf_land)
-
-    # compute reduced wind
-    gdf_track = compute_wind_speed_at_land(gdf_track)
-
-    return gdf_track
 
 # ----------------------------------------------------
 # MAIN WORKFLOW

--- a/tests/monitoring/test_rainfall_monitoring.py
+++ b/tests/monitoring/test_rainfall_monitoring.py
@@ -1,0 +1,36 @@
+import pandas as pd
+from dotenv import load_dotenv
+
+from src.utils.utils_plot import plot_chirps_gefs_forecast
+
+load_dotenv()
+
+
+def _dummy_chirps_gefs_df() -> pd.DataFrame:
+    """Create a minimal CHIRPS-GEFS DataFrame for testing.
+
+    Returns:
+        DataFrame with 'issue_date', 'valid_date', and 'mean' columns
+        for a single issue date with five lead times.
+    """
+    issue_date = pd.Timestamp("2026-03-25")
+    return pd.DataFrame(
+        [
+            {
+                "issue_date": issue_date,
+                "valid_date": issue_date + pd.Timedelta(days=lt),
+                "mean": 60.0 + lt * 5,
+            }
+            for lt in range(5)
+        ]
+    )
+
+
+def test_plot_chirps_gefs_forecast() -> None:
+    """Generate and upload a CHIRPS-GEFS rainfall forecast plot from dummy data.
+
+    Calls plot_chirps_gefs_forecast with today='test' and save=True,
+    uploading the plot to blob storage for retrieval in test_send_email.
+    """
+    df = _dummy_chirps_gefs_df()
+    plot_chirps_gefs_forecast(df, today="test", save=True)

--- a/tests/monitoring/test_send_email.py
+++ b/tests/monitoring/test_send_email.py
@@ -1,3 +1,82 @@
-from src.monitoring.send_email import get_latest_storm_track_plot
-
 import ocha_stratus as stratus
+import pandas as pd
+from dotenv import load_dotenv
+from geopandas import GeoDataFrame
+from shapely.geometry import Point
+
+from src.datasources import codab
+from src.monitoring.wind_speed_monitoring_ecmwf import plot_storm_track
+from src.utils import constants
+from src.utils.listmonk import create_campaign, generate_body_email, send_campaign
+from src.utils.utils_plot import plot_chirps_gefs_forecast
+
+load_dotenv()
+
+_MYANMAR_TIME = "12h00 01 Jan. 2026"
+_THRESHOLD_INFO = {
+    "wind_speed_threshold_reached": "NOT REACHED",
+    "rainfall_threshold_reached": "NOT REACHED",
+}
+
+
+def test_send_email() -> None:
+    """Send a monitoring email with both storm track and rainfall plots.
+
+    Generates the storm track plot from the test CSV and the rainfall
+    forecast plot from dummy CHIRPS-GEFS data, both uploaded to blob
+    storage with today='test'. Loads the PNG bytes for each and sends
+    a campaign email via Listmonk containing both plots.
+    """
+    
+    df = stratus.load_csv_from_blob(
+        blob_name=f"{constants.PROJECT_PREFIX}/processed/test_monitoring.csv"
+    )
+    geometry = [Point(xy) for xy in zip(df.lon, df.lat)]
+    gdf = GeoDataFrame(df, geometry=geometry, crs="EPSG:4326")
+    adm_boundaries = codab.load_codab_from_blob(admin_level=constants.adm_level)
+
+    plot_storm_track(
+        storms_area_interest=gdf,
+        adm_boundaries=adm_boundaries,
+        today="test",
+        hour="output",
+    )
+    storm_track_bytes = stratus.load_blob_data(
+        blob_name=(
+            f"{constants.PROJECT_PREFIX}/processed/storm_track_plot/"
+            "storm_track_plot_test_output.png"
+        )
+    )
+
+    issue_date = pd.Timestamp("2026-03-25")
+    df_rain = pd.DataFrame(
+        [
+            {
+                "issue_date": issue_date,
+                "valid_date": issue_date + pd.Timedelta(days=lt),
+                "mean": 10.0 + lt * 5,
+            }
+            for lt in range(5)
+        ]
+    )
+    plot_chirps_gefs_forecast(df_rain, today="test", save=True)
+    rainfall_bytes = stratus.load_blob_data(
+        blob_name=(
+            f"{constants.PROJECT_PREFIX}/processed/rainfall_forecast_plot/"
+            "rainfall_forecast_plot_test_.png"
+        )
+    )
+
+    storm_name = gdf["storm_name"].iloc[0]
+    campaign_body = generate_body_email(
+        storm_name=storm_name,
+        date_myanmar=_MYANMAR_TIME,
+        info=_THRESHOLD_INFO,
+        plot_bytes=[storm_track_bytes, rainfall_bytes],
+    )
+    campaign_id = create_campaign(
+        name="test_monitoring_email",
+        body=campaign_body,
+        subject=f"TEST - Anticipatory Action Myanmar - {_MYANMAR_TIME}",
+    )
+    send_campaign(campaign_id=campaign_id)


### PR DESCRIPTION
## Summary

- Check available CHIRPS-GEFS dates from server before downloading; raise on 403 to break the pipeline early
- Filter storm track plot points to those with wind speed at land >= 30 knots
- Fix rainfall exceedance and plot file naming conventions
- Handle missing plots gracefully in email body generation
- Add `test_rainfall_monitoring` to generate and upload a dummy CHIRPS-GEFS forecast plot to blob storage
- Add `test_send_email` to send a campaign email with both storm track and rainfall forecast plots
- Normalise CMA track columns (`storm_id` → `sid`, `valid_datetime` → `time`, `wind_speed_ms` → `max_sustained_wind`) and fix `filter_myanmar_tracks` to accept a DataFrame instead of CLIMADA track objects
- Add `run_update_cma.yml` GitHub Actions workflow running CMA monitoring on the same schedule as ECMWF
- Register `run_update_cma.yml` in the Slack bot workflow status report

## Test plan

- [ ] Run `pytest tests/monitoring/test_wind_speed_monitoring.py` to verify storm track plot generation
- [ ] Run `pytest tests/monitoring/test_rainfall_monitoring.py` to verify rainfall plot generation and blob upload
- [ ] Run `pytest tests/monitoring/test_send_email.py` to verify campaign email is sent with both plots

🤖 Generated with [Claude Code](https://claude.com/claude-code)